### PR TITLE
fix: remove interaction TTL — awaiting_input is permanent

### DIFF
--- a/service/src/durable-objects/widget-do.ts
+++ b/service/src/durable-objects/widget-do.ts
@@ -115,12 +115,6 @@ export class WidgetDurableObject implements DurableObject {
         manifest.state = "draft_expired";
         await this.setManifest(manifest);
       }
-    } else if (manifest.state === "awaiting_input" && manifest.interaction?.expires_at) {
-      const expiresAt = new Date(manifest.interaction.expires_at).getTime();
-      if (now > expiresAt) {
-        manifest.state = "interaction_expired";
-        await this.setManifest(manifest);
-      }
     }
 
     return manifest;
@@ -228,9 +222,6 @@ export class WidgetDurableObject implements DurableObject {
     // Transition state
     if (checked.interaction?.mode === "submit") {
       checked.state = "awaiting_input";
-      checked.interaction.expires_at = new Date(
-        Date.now() + (checked.interaction.ttl_seconds || 120) * 1000,
-      ).toISOString();
     } else {
       checked.state = "finalized";
     }

--- a/service/src/handlers/api-open.ts
+++ b/service/src/handlers/api-open.ts
@@ -28,8 +28,6 @@ export async function handleApiOpen(request: Request, env: Env): Promise<Respons
         mode: body.interaction.mode,
         prompt: body.interaction.prompt,
         schema: body.interaction.schema ?? null,
-        ttl_seconds: body.interaction.ttl_seconds ?? 120,
-        expires_at: null, // set on finalize
       }
     : null;
 

--- a/src/cli/commands/open.ts
+++ b/src/cli/commands/open.ts
@@ -9,7 +9,6 @@ export interface OpenArgs {
   fork?: string;
   "interaction-mode"?: string;
   "interaction-prompt"?: string;
-  "interaction-ttl"?: string;
 }
 
 export async function openCommand(client: WidgetClient, args: OpenArgs): Promise<void> {
@@ -22,9 +21,6 @@ export async function openCommand(client: WidgetClient, args: OpenArgs): Promise
       ? {
           mode: args["interaction-mode"] as "submit",
           prompt: args["interaction-prompt"] ?? "",
-          ttl_seconds: args["interaction-ttl"]
-            ? parseInt(args["interaction-ttl"], 10)
-            : undefined,
         }
       : undefined,
   };

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -2,7 +2,11 @@ import { parseArgs } from "node:util";
 
 // Enable HTTP(S) proxy support for Node.js fetch
 import { ProxyAgent, setGlobalDispatcher } from "undici";
-const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
+const proxyUrl =
+  process.env.HTTPS_PROXY ||
+  process.env.https_proxy ||
+  process.env.HTTP_PROXY ||
+  process.env.http_proxy;
 if (proxyUrl) {
   setGlobalDispatcher(new ProxyAgent(proxyUrl));
 }
@@ -35,7 +39,6 @@ Open options:
   --fork <widget_id>            Fork from existing widget
   --interaction-mode <mode>     "submit"
   --interaction-prompt <text>   Prompt shown to user
-  --interaction-ttl <n>         Interaction TTL in seconds
 
 Update options:
   --html <html>                 HTML content (or pipe via stdin)
@@ -62,7 +65,6 @@ function main(): void {
       mode: { type: "string" },
       "interaction-mode": { type: "string" },
       "interaction-prompt": { type: "string" },
-      "interaction-ttl": { type: "string" },
       fork: { type: "string" },
       "widget-id": { type: "string" },
       help: { type: "boolean", short: "h" },

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -17,7 +17,6 @@ export interface OpenRequest {
     mode: "submit";
     prompt: string;
     schema?: Record<string, unknown> | null;
-    ttl_seconds?: number; // default 120
   } | null;
 }
 

--- a/src/types/manifest.ts
+++ b/src/types/manifest.ts
@@ -2,13 +2,7 @@
  * Widget manifest — the core state record for a widget instance.
  */
 
-export type WidgetState =
-  | "draft"
-  | "draft_expired"
-  | "finalized"
-  | "awaiting_input"
-  | "submitted"
-  | "interaction_expired";
+export type WidgetState = "draft" | "draft_expired" | "finalized" | "awaiting_input" | "submitted";
 
 export interface WidgetManifest {
   widget_id: string;
@@ -26,6 +20,4 @@ export interface InteractionConfig {
   mode: "submit";
   prompt: string;
   schema: Record<string, unknown> | null;
-  ttl_seconds: number;
-  expires_at: string | null; // set when state transitions to awaiting_input
 }

--- a/tests/unit/expiry.test.ts
+++ b/tests/unit/expiry.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for widget expiry logic.
+ *
+ * Verifies that draft_expired works correctly, and that awaiting_input
+ * does NOT expire (interaction TTL was removed — see issue #3).
+ */
+
+import { describe, it, expect } from "vitest";
+import type { WidgetState } from "../../src/types/manifest.js";
+import type { InteractionConfig } from "../../src/types/manifest.js";
+
+describe("WidgetState type", () => {
+  it("includes awaiting_input as a valid state", () => {
+    const state: WidgetState = "awaiting_input";
+    expect(state).toBe("awaiting_input");
+  });
+
+  it("does not include interaction_expired", () => {
+    // interaction_expired was removed — awaiting_input is permanent until submit
+    const validStates: WidgetState[] = [
+      "draft",
+      "draft_expired",
+      "finalized",
+      "awaiting_input",
+      "submitted",
+    ];
+    expect(validStates).not.toContain("interaction_expired");
+    expect(validStates).toHaveLength(5);
+  });
+});
+
+describe("InteractionConfig type", () => {
+  it("does not have ttl_seconds or expires_at fields", () => {
+    const config: InteractionConfig = {
+      mode: "submit",
+      prompt: "Please confirm",
+      schema: null,
+    };
+    // Verify no TTL-related fields exist on the type
+    expect(config).toEqual({
+      mode: "submit",
+      prompt: "Please confirm",
+      schema: null,
+    });
+    expect("ttl_seconds" in config).toBe(false);
+    expect("expires_at" in config).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3

- Remove `interaction_expired` state — `awaiting_input` is now permanent until user submits
- Remove `ttl_seconds` and `expires_at` from `InteractionConfig`
- Remove `--interaction-ttl` CLI flag
- Add type-level tests verifying the removal

## Why

The interaction TTL (default 120s) was solving a non-existent problem. There are no resources to release:

- **DO** auto-hibernates when idle, wakes on demand
- **R2 HTML** is permanent storage
- **waitResolvers** only exist while agent actively calls `wait`

Neither agent nor user needs to be online simultaneously. The agent can `wait`, `get`, or come back later — the interaction is eventually consistent. The TTL was just silently breaking Feishu sidebar (and any slow-to-open context) with 409s.

## Test plan

- [x] 36/36 tests passing
- [x] Lint clean
- [x] Type tests verify `interaction_expired` is gone and `InteractionConfig` has no TTL fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Duoduo <duoduo@zhaob.in>